### PR TITLE
Move ember-legacy-views to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-legacy-views": "0.2.0",
     "ember-suave": "^1.0.0",
     "ember-try": "~0.0.8"
   },
@@ -44,7 +43,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-legacy-views": "0.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This causes the application to automatically include ember-legacy-views.