### PR TITLE
removeLoadingIndicator doc update

### DIFF
--- a/addon/components/ember-load-remover.js
+++ b/addon/components/ember-load-remover.js
@@ -11,7 +11,7 @@ export default Component.extend({
   },
   /**
    * remove the loading indicator. By default this
-   * removes the first element with the '.ember-load-indicator'
+   * removes all elements with the '.ember-load-indicator'
    * found CSS class from the DOM
    * @public
    */


### PR DESCRIPTION
Description previously indicated that 'the first' element with loadingIndicatorClass is removed, but the elems.forEach(...) function removes 'all' elements found in the document with loadingIndicatorClass, so change 'the first' to 'all'.