### PR TITLE
IE11-friendly way of removing the loading indicator

### DIFF
--- a/addon/components/ember-load-remover.js
+++ b/addon/components/ember-load-remover.js
@@ -20,8 +20,13 @@ export default Component.extend({
       this.get('ember-load-config.loadingIndicatorClass') ||
       'ember-load-indicator';
     const elems = document.querySelectorAll(`.${loadingIndicatorClass}`);
+    /**
+     * Very important to iterate over the NodeList this way,
+     * and remove the DOM elements via removeChild to maintain ie11
+     * compatibility
+     */
     for (let i = 0; i < elems.length; i++) {
-      elems[i].remove();
+      elems[i].parentNode.removeChild(elems[i]);
     }
   }
 });


### PR DESCRIPTION
Fixes #134